### PR TITLE
Add ability to change access modes

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 4.14.0
+version: 4.15.0
 appVersion: SeeValues
 home: https://minecraft.net/
 description: Minecraft server

--- a/charts/minecraft/templates/backupdir-pvc.yaml
+++ b/charts/minecraft/templates/backupdir-pvc.yaml
@@ -22,7 +22,7 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    {{ .Values.mcbackup.persistence.backupDir.accessModes | toYaml | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.mcbackup.persistence.backupDir.Size | quote }}

--- a/charts/minecraft/templates/datadir-pvc.yaml
+++ b/charts/minecraft/templates/datadir-pvc.yaml
@@ -25,7 +25,7 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    {{ .Values.persistence.dataDir.accessModes | toYaml | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.persistence.dataDir.Size | quote }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -398,6 +398,8 @@ persistence:
     # Set this to false if you don't care to persist state between restarts.
     enabled: false
     Size: 1Gi
+    accessModes:
+      - ReadWriteOnce
     # existingClaim: nil
     ## specify a subpath in the volume where the data is. Useful when sharing volumes with other apps.
     # subPath: /path/to/dataDir
@@ -523,6 +525,8 @@ mcbackup:
       enabled: false
       # existingClaim: nil
       Size: 1Gi
+      accessModes:
+        - ReadWriteOnce
 # dnsPolicy: ClusterFirst
 # dnsConfig:
 #   options:


### PR DESCRIPTION
Enables the user to alter the access mode to define Jobs in the extraDeployment array that can mount and modify the contents of the data directory.